### PR TITLE
Nonfunctional menu bar in mobile screens

### DIFF
--- a/src/assets/images/icons/NavBar.icons.tsx
+++ b/src/assets/images/icons/NavBar.icons.tsx
@@ -4,13 +4,13 @@ export const CloseIcon = () => {
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
-      stroke-width="1.5"
+      strokeWidth="1.5"
       stroke="currentColor"
-      className="w-6 h-6"
+      className="h-6 w-6"
     >
       <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeLinecap="round"
+        strokeLinejoin="round"
         d="M6 18 18 6M6 6l12 12"
       />
     </svg>

--- a/src/assets/images/icons/NavBar.icons.tsx
+++ b/src/assets/images/icons/NavBar.icons.tsx
@@ -1,0 +1,37 @@
+export const CloseIcon = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke-width="1.5"
+      stroke="currentColor"
+      className="w-6 h-6"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M6 18 18 6M6 6l12 12"
+      />
+    </svg>
+  )
+}
+
+export const HamburgerIcon = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      className="h-6 w-6"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        d="M4 6h16M4 12h16m-7 6h7"
+      ></path>
+    </svg>
+  )
+}

--- a/src/components/Navbar/MenuOverlay.tsx
+++ b/src/components/Navbar/MenuOverlay.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { NavLink } from 'react-router-dom'
+import { motion, AnimatePresence } from 'framer-motion'
+
+// Define the props interface for MenuOverlay component
+interface MenuOverlayProps {
+  menuBarOpen: boolean
+  setMenuBarOpen: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+// Define the navigation links
+const links = [
+  {
+    title: 'Component',
+    to: '/',
+  },
+  {
+    title: 'Template',
+    to: '/Template',
+  },
+  {
+    title: 'Docs',
+    to: '/Docs',
+  },
+]
+
+// MenuOverlay component definition
+const MenuOverlay: React.FC<MenuOverlayProps> = ({
+  menuBarOpen,
+  setMenuBarOpen,
+}) => {
+  // Handler to close the menu
+  const handleClick = () => {
+    setMenuBarOpen(false)
+  }
+
+  // Render the menu overlay
+  return (
+    <section>
+      {/* AnimatePresence handles animations */}
+      <AnimatePresence>
+        {menuBarOpen && (
+          <motion.ul
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.4 }}
+            className="grid grid-rows-3 md:hidden absolute text-center gap-y-2 z-10 left-0 right-0 mx-auto w-[90%] rounded-lg bg-gradient-to-r from-slate-600 to-transparent p-4 backdrop-blur-sm md:w-[95%] xl:w-[75%]"
+          >
+            {/* Map through links to create navigation items */}
+            {links.map((link, index) => (
+              <motion.li
+                key={index}
+                initial={{ opacity: 0, y: -10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.3, delay: index * 0.1 }}
+              >
+                {/* Navigation links */}
+                <NavLink
+                  to={link.to}
+                  className="block text-white hover:text-gray-300"
+                  onClick={handleClick}
+                >
+                  {link.title}
+                </NavLink>
+              </motion.li>
+            ))}
+          </motion.ul>
+        )}
+      </AnimatePresence>
+    </section>
+  )
+}
+
+export default MenuOverlay

--- a/src/components/Navbar/MenuOverlay.tsx
+++ b/src/components/Navbar/MenuOverlay.tsx
@@ -58,7 +58,7 @@ const MenuOverlay: React.FC<MenuOverlayProps> = ({
             animate={{ x: 0 }} // Slide in from the left
             exit={{ x: -100 }} // Slide out to the left
             transition={{ duration: 0.5 }}
-            className="fixed insert-0 h-screen w-screen flex flex-col justify-center items-center gap-y-16 backdrop-blur-sm z-30 md:hidden bg-gradient-to-r from-slate-600 to-transparent text-center p-4"
+            className="fixed insert-0 h-full w-screen flex flex-col justify-center items-center gap-y-16 backdrop-blur-sm z-30 md:hidden bg-gradient-to-r from-slate-600 to-transparent text-center p-4"
           >
             <button
               className="text-white absolute top-9 right-8"

--- a/src/components/Navbar/MenuOverlay.tsx
+++ b/src/components/Navbar/MenuOverlay.tsx
@@ -39,21 +39,24 @@ const MenuOverlay: React.FC<MenuOverlayProps> = ({
     <section>
       {/* AnimatePresence handles animations */}
       <AnimatePresence>
-        {/* eslint-disable-next-line */}
         {menuBarOpen && (
+          /* eslint-disable */
           <motion.ul
-            initial={{ opacity: 0, y: -10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.4 }}
-            className="absolute left-0 right-0 mx-auto grid text-center p-4 gap-y-2 rounded-lg backdrop-blur-sm z-10 w-[90%] md:w-[95%] xl:w-[75%] grid-rows-3 md:hidden bg-gradient-to-r from-slate-600 to-transparent"
+            initial={{ x: -100 }} // Start position outside the screen on the left
+            animate={{ x: 0 }} // Slide in from the left
+            exit={{ x: -100 }} // Slide out to the left
+            transition={{ duration: 0.5 }}
+            className="absolute h-screen w-screen flex flex-col justify-center items-center gap-y-16 backdrop-blur-sm z-30 md:hidden bg-gradient-to-r from-slate-600 to-transparent text-center p-4"
           >
+            {/* eslint-enable */}
             {/* Map through links to create navigation items */}
             {links.map((link, index) => (
               <motion.li
                 key={index}
-                initial={{ opacity: 0, y: -10 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.3, delay: index * 0.1 }}
+                initial={{ x: -100 }} // Start position outside the screen on the left
+                animate={{ x: 0 }} // Slide in from the left
+                exit={{ x: -100 }} // Slide out to the left
+                transition={{ duration: 0.3, delay: index * 0.01 }}
               >
                 {/* Navigation links */}
                 <NavLink

--- a/src/components/Navbar/MenuOverlay.tsx
+++ b/src/components/Navbar/MenuOverlay.tsx
@@ -44,7 +44,7 @@ const MenuOverlay: React.FC<MenuOverlayProps> = ({
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.4 }}
-            className="grid grid-rows-3 md:hidden absolute text-center gap-y-2 z-10 left-0 right-0 mx-auto w-[90%] rounded-lg bg-gradient-to-r from-slate-600 to-transparent p-4 backdrop-blur-sm md:w-[95%] xl:w-[75%]"
+            className="absolute z-10 left-0 right-0 mx-auto w-[90%] md:w-[95%] xl:w-[75%] grid grid-rows-3 md:hidden text-center gap-y-2 rounded-lg bg-gradient-to-r from-slate-600 to-transparent p-4 backdrop-blur-sm"
           >
             {/* Map through links to create navigation items */}
             {links.map((link, index) => (

--- a/src/components/Navbar/MenuOverlay.tsx
+++ b/src/components/Navbar/MenuOverlay.tsx
@@ -44,7 +44,7 @@ const MenuOverlay: React.FC<MenuOverlayProps> = ({
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.4 }}
-            className="absolute left-0 right-0 mx-auto grid text-center p-4 gap-y-2 rounded-lg backdrop-blur-sm z-10 w-[90%] md:w-[95%] xl:w-[75%] grid-rows-3 md:hidden bg-gradient-to-r from-slate-600 to-transparent"
+            className="absolute left-0 right-0 mx-auto p-4 grid text-center gap-y-2 rounded-lg backdrop-blur-sm z-10 w-[90%] md:w-[95%] xl:w-[75%] grid-rows-3 md:hidden bg-gradient-to-r from-slate-600 to-transparent"
           >
             {/* Map through links to create navigation items */}
             {links.map((link, index) => (

--- a/src/components/Navbar/MenuOverlay.tsx
+++ b/src/components/Navbar/MenuOverlay.tsx
@@ -44,7 +44,7 @@ const MenuOverlay: React.FC<MenuOverlayProps> = ({
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.4 }}
-            className="absolute z-10 left-0 right-0 mx-auto w-[90%] md:w-[95%] xl:w-[75%] grid grid-rows-3 md:hidden text-center gap-y-2 rounded-lg bg-gradient-to-r from-slate-600 to-transparent p-4 backdrop-blur-sm"
+            className="absolute left-0 right-0 mx-auto grid text-center p-4 gap-y-2 rounded-lg backdrop-blur-sm z-10 w-[90%] md:w-[95%] xl:w-[75%] grid-rows-3 md:hidden bg-gradient-to-r from-slate-600 to-transparent"
           >
             {/* Map through links to create navigation items */}
             {links.map((link, index) => (

--- a/src/components/Navbar/MenuOverlay.tsx
+++ b/src/components/Navbar/MenuOverlay.tsx
@@ -60,7 +60,6 @@ const MenuOverlay: React.FC<MenuOverlayProps> = ({
             transition={{ duration: 0.5 }}
             className="fixed insert-0 h-screen w-screen flex flex-col justify-center items-center gap-y-16 backdrop-blur-sm z-30 md:hidden bg-gradient-to-r from-slate-600 to-transparent text-center p-4"
           >
-            {/* eslint-enable */}
             <button
               className="text-white absolute top-9 right-8"
               onClick={() => {

--- a/src/components/Navbar/MenuOverlay.tsx
+++ b/src/components/Navbar/MenuOverlay.tsx
@@ -39,12 +39,13 @@ const MenuOverlay: React.FC<MenuOverlayProps> = ({
     <section>
       {/* AnimatePresence handles animations */}
       <AnimatePresence>
+        {/* eslint-disable-next-line */}
         {menuBarOpen && (
           <motion.ul
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.4 }}
-            className="absolute left-0 right-0 mx-auto p-4 grid text-center gap-y-2 rounded-lg backdrop-blur-sm z-10 w-[90%] md:w-[95%] xl:w-[75%] grid-rows-3 md:hidden bg-gradient-to-r from-slate-600 to-transparent"
+            className="absolute left-0 right-0 mx-auto grid text-center p-4 gap-y-2 rounded-lg backdrop-blur-sm z-10 w-[90%] md:w-[95%] xl:w-[75%] grid-rows-3 md:hidden bg-gradient-to-r from-slate-600 to-transparent"
           >
             {/* Map through links to create navigation items */}
             {links.map((link, index) => (

--- a/src/components/Navbar/MenuOverlay.tsx
+++ b/src/components/Navbar/MenuOverlay.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { NavLink } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
+import { CloseIcon } from '../../assets/images/icons/NavBar.icons'
+import { useEffect } from 'react'
 
 // Define the props interface for MenuOverlay component
 interface MenuOverlayProps {
@@ -34,6 +36,16 @@ const MenuOverlay: React.FC<MenuOverlayProps> = ({
     setMenuBarOpen(false)
   }
 
+  useEffect(() => {
+    if (menuBarOpen) {
+      document.body.style.overflow = 'hidden' // Disable scroll
+      document.body.style.height = '100vh' // Lock the body height
+    } else {
+      document.body.style.overflow = 'auto' // Enable scroll
+      document.body.style.height = 'auto' // Unlock the body height
+    }
+  }, [menuBarOpen])
+
   // Render the menu overlay
   return (
     <section>
@@ -46,9 +58,17 @@ const MenuOverlay: React.FC<MenuOverlayProps> = ({
             animate={{ x: 0 }} // Slide in from the left
             exit={{ x: -100 }} // Slide out to the left
             transition={{ duration: 0.5 }}
-            className="absolute h-screen w-screen flex flex-col justify-center items-center gap-y-16 backdrop-blur-sm z-30 md:hidden bg-gradient-to-r from-slate-600 to-transparent text-center p-4"
+            className="fixed insert-0 h-screen w-screen flex flex-col justify-center items-center gap-y-16 backdrop-blur-sm z-30 md:hidden bg-gradient-to-r from-slate-600 to-transparent text-center p-4"
           >
             {/* eslint-enable */}
+            <button
+              className="text-white absolute top-9 right-8"
+              onClick={() => {
+                setMenuBarOpen(false)
+              }}
+            >
+              <CloseIcon />
+            </button>
             {/* Map through links to create navigation items */}
             {links.map((link, index) => (
               <motion.li

--- a/src/components/Navbar/MenuOverlay.tsx
+++ b/src/components/Navbar/MenuOverlay.tsx
@@ -1,8 +1,7 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { NavLink } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { CloseIcon } from '../../assets/images/icons/NavBar.icons'
-import { useEffect } from 'react'
 
 // Define the props interface for MenuOverlay component
 interface MenuOverlayProps {
@@ -44,6 +43,11 @@ const MenuOverlay: React.FC<MenuOverlayProps> = ({
       document.body.style.overflow = 'auto' // Enable scroll
       document.body.style.height = 'auto' // Unlock the body height
     }
+
+    return () => {
+      document.body.style.overflow = 'auto'
+      document.body.style.height = 'auto'
+    }
   }, [menuBarOpen])
 
   // Render the menu overlay
@@ -54,11 +58,11 @@ const MenuOverlay: React.FC<MenuOverlayProps> = ({
         {menuBarOpen && (
           /* eslint-disable */
           <motion.ul
-            initial={{ x: -100 }} // Start position outside the screen on the left
+            initial={{ x: '-100%' }} // Start position outside the screen on the left
             animate={{ x: 0 }} // Slide in from the left
-            exit={{ x: -100 }} // Slide out to the left
+            exit={{ x: '-100%' }} // Slide out to the left
             transition={{ duration: 0.5 }}
-            className="fixed insert-0 h-full w-screen flex flex-col justify-center items-center gap-y-16 backdrop-blur-sm z-30 md:hidden bg-gradient-to-r from-slate-600 to-transparent text-center p-4"
+            className="fixed left-0 top-0 h-full w-screen flex flex-col justify-center items-center gap-y-16 backdrop-blur-sm z-30 md:hidden bg-gradient-to-r from-slate-600 to-transparent text-center p-4"
           >
             <button
               className="text-white absolute top-9 right-8"
@@ -72,9 +76,9 @@ const MenuOverlay: React.FC<MenuOverlayProps> = ({
             {links.map((link, index) => (
               <motion.li
                 key={index}
-                initial={{ x: -100 }} // Start position outside the screen on the left
+                initial={{ x: '-100%' }} // Start position outside the screen on the left
                 animate={{ x: 0 }} // Slide in from the left
-                exit={{ x: -100 }} // Slide out to the left
+                exit={{ x: '-100%' }} // Slide out to the left
                 transition={{ duration: 0.3, delay: index * 0.01 }}
               >
                 {/* Navigation links */}

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -137,7 +137,6 @@ const Navbar = () => {
                 <button
                   className="text-white"
                   onClick={() => {
-                    console.log('X mark clicked')
                     setMenuBarOpen(false)
                   }}
                 >

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -6,11 +6,19 @@ import { easeOut, motion } from 'framer-motion'
 import { componentsList } from '../../utils/constant/values'
 import { Component } from '../../utils/types/types'
 import TailoredUIIcon from '../../assets/images/icons/TailoredUI.icon'
+import MenuOverlay from './MenuOverlay.jsx'
+import {
+  HamburgerIcon,
+  CloseIcon,
+} from '../../assets/images/icons/NavBar.icons.js'
 
 const Navbar = () => {
   const [isSearchVisible, setIsSearchVisible] = useState(false)
   const [searchedValue, setSearchedValue] = useState<string>('')
   const [results, setResults] = useState<Component[]>([])
+
+  // State variables to indicate whether menu bar is open or not
+  const [menuBarOpen, setMenuBarOpen] = useState(false)
 
   useEffect(() => {
     if (searchedValue != '') {
@@ -115,23 +123,27 @@ const Navbar = () => {
             <button className="ml-4 hidden rounded-md bg-blue-500 px-8 py-2 text-white md:inline-block">
               Get Started
             </button>
+
+            {/*Menu for mobile screens*/}
             <div className="md:hidden">
-              <button className="text-white">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  className="h-6 w-6"
+              {!menuBarOpen ? (
+                <button
+                  className="text-white"
+                  onClick={() => setMenuBarOpen(true)}
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M4 6h16M4 12h16m-7 6h7"
-                  ></path>
-                </svg>
-              </button>
+                  <HamburgerIcon />
+                </button>
+              ) : (
+                <button
+                  className="text-white"
+                  onClick={() => {
+                    console.log('X mark clicked')
+                    setMenuBarOpen(false)
+                  }}
+                >
+                  <CloseIcon />
+                </button>
+              )}
             </div>
           </div>
         </div>
@@ -204,6 +216,8 @@ const Navbar = () => {
           </motion.ul>
         )}
       </Modal>
+      {/* Menu Overlay Component */}
+      <MenuOverlay menuBarOpen={menuBarOpen} setMenuBarOpen={setMenuBarOpen} />
     </motion.div>
   )
 }

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -55,6 +55,8 @@ const Navbar = () => {
       animate={{ opacity: 1 }}
       transition={{ duration: 1.0, ease: easeOut }}
     >
+      {/* Menu Overlay Component */}
+      <MenuOverlay menuBarOpen={menuBarOpen} setMenuBarOpen={setMenuBarOpen} />
       <nav className="relative z-10 m-auto my-4 w-[90%] rounded-lg bg-gradient-to-r from-slate-600 to-transparent p-4 backdrop-blur-sm md:w-[95%] xl:w-[75%]">
         <div className="container mx-auto flex items-center justify-between">
           <div className="flex items-center gap-2">
@@ -215,8 +217,6 @@ const Navbar = () => {
           </motion.ul>
         )}
       </Modal>
-      {/* Menu Overlay Component */}
-      <MenuOverlay menuBarOpen={menuBarOpen} setMenuBarOpen={setMenuBarOpen} />
     </motion.div>
   )
 }

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -7,10 +7,7 @@ import { componentsList } from '../../utils/constant/values'
 import { Component } from '../../utils/types/types'
 import TailoredUIIcon from '../../assets/images/icons/TailoredUI.icon'
 import MenuOverlay from './MenuOverlay.jsx'
-import {
-  HamburgerIcon,
-  CloseIcon,
-} from '../../assets/images/icons/NavBar.icons.js'
+import { HamburgerIcon } from '../../assets/images/icons/NavBar.icons.js'
 
 const Navbar = () => {
   const [isSearchVisible, setIsSearchVisible] = useState(false)
@@ -128,23 +125,12 @@ const Navbar = () => {
 
             {/*Menu for mobile screens*/}
             <div className="md:hidden">
-              {!menuBarOpen ? (
-                <button
-                  className="text-white"
-                  onClick={() => setMenuBarOpen(true)}
-                >
-                  <HamburgerIcon />
-                </button>
-              ) : (
-                <button
-                  className="text-white"
-                  onClick={() => {
-                    setMenuBarOpen(false)
-                  }}
-                >
-                  <CloseIcon />
-                </button>
-              )}
+              <button
+                className="text-white"
+                onClick={() => setMenuBarOpen(true)}
+              >
+                <HamburgerIcon />
+              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Pull Request

### Description

Added the hamburger menu bar functionality in mobile screens while maintaining the styling in consistent with that of the navigation bar. The menu overlay appears when the hamburger icon is clicked and upon clicking the close icon, the menu collapses. I have added detailed documentation for all the modified files for easy understanding.

### Related Issues

#27 - Non Functional Menu Icon on Mobile Screens

### Screenshots

![image](https://github.com/TailoredUI/TailoredUI/assets/127531721/f8e980c9-1283-4317-b1b1-9a2bc75171fa)

### Checklist

- [✔] I have tested these changes locally.
- [✔] My code follows the project's coding guidelines.
- [✔] I have updated the documentation, if necessary.
- [✔] I have added tests to cover my changes.

### Additional Notes

Please let me know if any changes are required. 
