### PR TITLE
Fixed the overlapping elements issue on all screens.

### DIFF
--- a/src/components/Home/FeatureSection.tsx
+++ b/src/components/Home/FeatureSection.tsx
@@ -29,7 +29,7 @@ const FeatureSection = () => {
   const isCardContainerInView = useInView(cardContainerRef, { once: true })
 
   return (
-    <section className="relative">
+    <section className="relative my-6">
       {/* <div className="bg-slate-400 h-16 w-full absolute left-0" /> */}
       <div className="mb-16 h-max overflow-hidden">
         <div className="mb-16 flex flex-col items-center text-center">

--- a/src/components/Home/HeroSection.tsx
+++ b/src/components/Home/HeroSection.tsx
@@ -7,7 +7,7 @@ import TailwindIcon from '../../assets/images/icons/Tailwind.icon'
 
 const HeroSection = () => {
   return (
-    <section className="relative h-[calc(100vh-6rem)] flex items-center mt-10 md:mt-0">
+    <section className="relative flex h-[calc(100vh-6rem)] items-center mt-10 md:mt-0">
       {/* <HeroImage className="absolute bottom-0 right-0 h-full opacity-30 lg:w-full lg:h-max sm:opacity-100" /> */}
       {/* <FeatureImage className="absolute -top-44 right-0 h-[100vh] w-full object-cover -z-10 opacity-100 rotate-180 hidden sm:block" /> */}
 

--- a/src/components/Home/HeroSection.tsx
+++ b/src/components/Home/HeroSection.tsx
@@ -7,7 +7,7 @@ import TailwindIcon from '../../assets/images/icons/Tailwind.icon'
 
 const HeroSection = () => {
   return (
-    <section className="relative flex h-[calc(100vh-6rem)] items-center mt-10 md:mt-0">
+    <section className="relative mt-10 flex h-[calc(100vh-6rem)] items-center md:mt-0">
       {/* <HeroImage className="absolute bottom-0 right-0 h-full opacity-30 lg:w-full lg:h-max sm:opacity-100" /> */}
       {/* <FeatureImage className="absolute -top-44 right-0 h-[100vh] w-full object-cover -z-10 opacity-100 rotate-180 hidden sm:block" /> */}
 

--- a/src/components/Home/HeroSection.tsx
+++ b/src/components/Home/HeroSection.tsx
@@ -7,7 +7,7 @@ import TailwindIcon from '../../assets/images/icons/Tailwind.icon'
 
 const HeroSection = () => {
   return (
-    <section className="relative flex h-[calc(100vh-6rem)] items-center">
+    <section className="relative flex items-center">
       {/* <HeroImage className="absolute bottom-0 right-0 h-full opacity-30 lg:w-full lg:h-max sm:opacity-100" /> */}
       {/* <FeatureImage className="absolute -top-44 right-0 h-[100vh] w-full object-cover -z-10 opacity-100 rotate-180 hidden sm:block" /> */}
 

--- a/src/components/Home/HeroSection.tsx
+++ b/src/components/Home/HeroSection.tsx
@@ -7,7 +7,7 @@ import TailwindIcon from '../../assets/images/icons/Tailwind.icon'
 
 const HeroSection = () => {
   return (
-    <section className="relative flex items-center">
+    <section className="relative h-[calc(100vh-6rem)] flex items-center mt-10 md:mt-0">
       {/* <HeroImage className="absolute bottom-0 right-0 h-full opacity-30 lg:w-full lg:h-max sm:opacity-100" /> */}
       {/* <FeatureImage className="absolute -top-44 right-0 h-[100vh] w-full object-cover -z-10 opacity-100 rotate-180 hidden sm:block" /> */}
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,7 +3,7 @@ import HeroSection from '../components/Home/HeroSection'
 
 const Home = () => {
   return (
-    <div className="flex flex-col md:gap-y-6">
+    <div className="flex flex-col md:gap-16 lg:gap-y-0 md:py-16 lg:py-0">
       <HeroSection />
       <FeatureSection />
     </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,7 +3,7 @@ import HeroSection from '../components/Home/HeroSection'
 
 const Home = () => {
   return (
-    <div className="flex flex-col md:py-16 lg:py-0 md:gap-16 lg:gap-y-0">
+    <div className="flex flex-col md:gap-16 md:py-16 lg:gap-y-0 lg:py-0">
       <HeroSection />
       <FeatureSection />
     </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,7 +3,7 @@ import HeroSection from '../components/Home/HeroSection'
 
 const Home = () => {
   return (
-    <div className="flex flex-col md:gap-16 lg:gap-y-0 md:py-16 lg:py-0">
+    <div className="flex flex-col md:py-16 lg:py-0 md:gap-16 lg:gap-y-0">
       <HeroSection />
       <FeatureSection />
     </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,10 +3,10 @@ import HeroSection from '../components/Home/HeroSection'
 
 const Home = () => {
   return (
-    <>
+    <div className="flex flex-col md:gap-y-6">
       <HeroSection />
       <FeatureSection />
-    </>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Pull Request

### Description

Fixed the overlapping elements an all screens:
1. The title of the hero section, "Craft Tailored UI Experiences Seamlessly" was getting cut in various screen sizes. It is now fixed.
2. The title of the featured section, "Tailor Your Experiences" was overlapping with the elements of the hero section in tablet screen and a couple of other screen sizes. It is now fixed.
3. The overlapping elements issue is fixed in mobile, tablet and large screen sizes.

### Related Issues

#28 : UI Issue: Elements overlapping in Tablet Screen.

### Screenshots

![image](https://github.com/TailoredUI/TailoredUI/assets/127531721/c7dd5b2f-e5fa-4fb3-98e7-fcfde0eec8b4)
![image](https://github.com/TailoredUI/TailoredUI/assets/127531721/f9578687-efcb-4edb-915d-e7121aa93036)
![image](https://github.com/TailoredUI/TailoredUI/assets/127531721/8f4f2303-a9fb-4670-89ac-cac9ee4ba278)
![image](https://github.com/TailoredUI/TailoredUI/assets/127531721/a893012c-c367-41d8-8a18-42efbe3eef58)
![image](https://github.com/TailoredUI/TailoredUI/assets/127531721/669e0f27-abc6-4c87-9a68-42acef451bdc)


### Checklist

- [✔] I have tested these changes locally.
- [✔] My code follows the project's coding guidelines.
- [✔] I have updated the documentation, if necessary.
- [✔] I have added tests to cover my changes.

### Additional Notes

Please let me know if any changes are required.
